### PR TITLE
FIX 后台用户管理页面新增用户表单根据用户权限的动态调整

### DIFF
--- a/admin/src/composables/useCRUD.js
+++ b/admin/src/composables/useCRUD.js
@@ -11,6 +11,7 @@ const ACTIONS = {
 /**
  * @typedef {object} FormObject
  * @property {string} name - 名称
+ * @property {object} initForm - 初始表单对象
  * @property {Function} doCreate - 执行创建操作的函数
  * @property {Function} doDelete - 执行删除操作的函数
  * @property {Function} doUpdate - 执行更新操作的函数
@@ -21,7 +22,7 @@ const ACTIONS = {
  * 可复用的 CRUD 操作
  * @param {FormObject} options
  */
-export function useCRUD({ name, doCreate, doDelete, doUpdate, refresh }) {
+export function useCRUD({ name, initForm = {}, doCreate, doDelete, doUpdate, refresh }) {
   const modalVisible = ref(false) // 弹框显示
   /** @type {'add' | 'edit' | 'view'} 弹窗操作类型 */
   const modalAction = ref('')
@@ -30,10 +31,13 @@ export function useCRUD({ name, doCreate, doDelete, doUpdate, refresh }) {
   /** 弹窗标题 */
   const modalTitle = computed(() => ACTIONS[modalAction.value] + name) // 弹窗标题
 
+  const { formModel: modalForm, formRef: modalFormRef, validation } = useForm(initForm)
+
   /** 新增 */
   function handleAdd() {
     modalAction.value = 'add'
     modalVisible.value = true
+    modalForm.value = { ...initForm } // 使用初始表单
   }
 
   /** 修改 */

--- a/admin/src/composables/useForm.js
+++ b/admin/src/composables/useForm.js
@@ -1,0 +1,29 @@
+import { ref } from 'vue'
+
+/**
+ * 可复用的表单对象
+ * @param {any} initForm 表单初始值
+ */
+export function useForm(initForm = {}) {
+  const formRef = ref(null)
+  const formModel = ref({ ...initForm })
+
+  const validation = async () => {
+    try {
+      await formRef.value?.validate()
+      return true
+    }
+    catch (error) {
+      return false
+    }
+  }
+
+  const rules = {
+    required: {
+      required: true,
+      message: '此为必填项',
+      trigger: ['blur', 'change'],
+    },
+  }
+  return { formRef, formModel, validation, rules }
+}

--- a/admin/src/views/user/list/index.vue
+++ b/admin/src/views/user/list/index.vue
@@ -43,6 +43,15 @@ onMounted(() => {
   $table.value?.handleSearch()
 })
 
+const initForm = {
+  SID: '',
+  password: '',
+  name: '',
+  role: whatRole.value,
+  grade: userStore.grade,
+  user_class: userStore.user_class,
+}
+
 const {
   modalVisible,
   modalLoading,
@@ -55,6 +64,7 @@ const {
   modalFormRef,
 } = useCRUD({
   name: '管理员',
+  initForm,
   doCreate: api.saveUser,
   doUpdate: api.UpdateUser,
   doDelete: api.deleteBackendUser,


### PR DESCRIPTION
之前无论是超管（辅导员或教务老师）还是班主任，都能新增任意身份（包括超管）、任意年级和班级的管理员账号。为了降低班主任的操作权限，登录用户为班主任时，我们固定<CrudModal>表单的相应行，由于新增管理员和编辑管理员都是用的<CrudModal>,这样虽然实现了班主任不能通过编辑本班管理员账号来更改本班管理员账号的身份、年级和班级。但是这样却导致了班主任新增管理员不能选择身份、年级和班级的问题。我们需要确保班主任账户在新增管理员时，年级和班级字段自动填充为当前班主任的年级和班级并不能更改，且角色字段固定为班长。
![image](https://github.com/user-attachments/assets/7719ddbb-7b35-4fad-913b-1a6c2b56804a)
![image](https://github.com/user-attachments/assets/fb12668b-5617-432f-93af-86c9f55aaea4)
![image](https://github.com/user-attachments/assets/a188d091-b696-4887-9526-c5db5b39e85e)
![image](https://github.com/user-attachments/assets/fc224c42-04b2-4fb8-b50e-e5092798db44)

这样的意义是使班主任不能新增有后台管理系统所有权限的超管、或其他年级的班主任或班长管理员账号。保证后台系统的安全性和隐私性。
分析：问题的原因是因为该项目使用了对CRUD操作的通用Hook封装，而新增和编辑使用相同的组件modalForm（，而发现新增时modalForm.value = { ...initForm }，使用初始表单；修改时modalForm.value = { ...row }，使用table当前行数据，即选择的用户的数据。
可以通过新增时传一个initForm的值给modalForm，解决“班主任新增管理员不能选择身份、年级和班级的问题”。
具体实现为设置新增表单初值为initForm，传给useCRUD，initForm的角色（role）属性为根据当前用户设置新增表单的角色，年级属性（grade）和班级属性（user_class）为全局存储的登录用户的年级和班级
![image](https://github.com/user-attachments/assets/6535f441-602a-4305-bbc6-58ee1637f123)
![image](https://github.com/user-attachments/assets/247e40c9-0e83-4664-bb26-530c50e76cc2)

